### PR TITLE
Fixed "Could not find iframe window" errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ frametalk.replyOn = function(name, callback) {
 };
 
 frametalk._getSourceFrameWindow = function(eventSource) {
-	if (eventSource instanceof Window) {
+	if (frametalk._isWindow(eventSource)) {
 		return eventSource;
 	}
 
@@ -60,6 +60,14 @@ frametalk._getSourceFrameWindow = function(eventSource) {
 	}
 
 	return sourceFrame.contentWindow;
+};
+
+frametalk._isWindow = function(obj) {
+	if (typeof(window.constructor) === 'undefined') {
+		return obj instanceof window.constructor;
+	} else {
+		return obj.window === obj;
+	}
 };
 
 function addRequestId(data, requestId) {


### PR DESCRIPTION
Frametalk was failing for me when I used replyOn, because event.source was not an instance of Window. This commit provides a better way of detecting if an object is a window, based on this Stack Overflow answer: https://stackoverflow.com/a/6229603

It now works properly and no longer gives me any errors :)